### PR TITLE
Enable open in new tab

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -2,6 +2,7 @@ import {
 	AbstractInputSuggest,
 	App,
 	IconName,
+	Keymap,
 	Notice,
 	Plugin,
 	PluginSettingTab,
@@ -73,7 +74,11 @@ export default class PinnedNotesPlugin extends Plugin {
 				note.icon === "" ? "file" : note.icon,
 				note.title,
 				async (e) => {
-					await this.app.workspace.openLinkText(note.path, "")
+					await this.app.workspace.openLinkText(
+						note.path,
+						"",
+						e.button == 1 || e.button == 2 || Keymap.isModifier(e, "Mod")
+					);
 				}
 			)
 		)


### PR DESCRIPTION
Thank you for making this plugin, it is very helpful.

I see some people have requested to be able to optionally open a note in a new tab instead of replacing the current one (see https://github.com/vasilcoin002/pinned-notes-plugin-obsidian/issues/5). This PR adds that feature.

Let me know if you have any questions.